### PR TITLE
Fix for path mutation sent to 'onSet' method

### DIFF
--- a/index.js
+++ b/index.js
@@ -37,6 +37,7 @@ var Factory = function (state, defaultArgs) {
       return Value(path, state);
     },
     onSet: function (path, value) {
+      path = path.slice();
       var key = path.pop();
       state = Value(path, state).set(key, value);
     },


### PR DESCRIPTION
The path parameter is mutated when `pop()` is applied so if you try to use the same path object again in another `set()` call it will not work. The purpose for this is to store the current path an reuse later.

``` javascript
  const path = [1, 0, 'prop'];
  state.set(path, value);
  state.set('currentPath', path); // path var is not accurate anymore
```
